### PR TITLE
Add a backtrace member to the Command module

### DIFF
--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -73,6 +73,7 @@ module Patir
     #
     #Call this if you want to pretend that it was never executed
     def reset
+      @backtrace=""
       @exec_time=0
       @output=""
       @error=""

--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -41,6 +41,12 @@ module Patir
       @error||=""
       return @error
     end
+    #returns the error output for the command
+    def backtrace
+      #initialize nil values to something meaningful
+      @backtrace||=""
+      return @backtrace
+    end
     #returns the execution time (duration) for the command
     def exec_time
       #initialize nil values to something meaningful
@@ -494,6 +500,7 @@ module Patir
       @context=context
       @error=""
       @output=""
+      @backtrace=""
       begin
         t1=Time.now
         Dir.chdir(@working_directory) do
@@ -502,7 +509,7 @@ module Patir
         end
       rescue StandardError
         @error<<"\n#{$!.message}"
-        @error<<"\n#{$!.backtrace}" if $DEBUG
+        @backtrace=$@
         @status=:error
       ensure
         @exec_time=Time.now-t1

--- a/test/test_patir_command.rb
+++ b/test/test_patir_command.rb
@@ -26,6 +26,7 @@ class TestCommand<Minitest::Test
   #tests the default values set by the module
   def test_module
     obj=MockCommandObject.new
+    assert_equal("",obj.backtrace)
     assert_equal("",obj.name)
     assert_equal(:not_executed,obj.status)
     assert(!obj.run?)
@@ -242,6 +243,7 @@ class TestRubyCommand<Minitest::Test
     cmd=RubyCommand.new("test"){raise "Error"}
     assert(cmd.run)
     assert(!cmd.success?, "Successful?!")
+    refute(cmd.backtrace.empty?)
     assert_equal("\nError", cmd.error)
     assert_equal(:error, cmd.status)
   end


### PR DESCRIPTION
This allows to store backtraces of failed RubyCommand invocations.