### PR TITLE
Enhance and unify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,27 @@
 
 [patir](http://patir.rubyforge.org) provides code to enable project automation tasks:
 
- * A logging format for ruby's built-in Logger
- * A command abstraction with a platform independent implementation for running shell commands and ruby code
- * Command sequences using the same command abstraction as single commands.
- * Configuration format for configuration files written in ruby.
+* an adjusted logging format for the built-in logger of Ruby
+* a command abstraction with a platform independent implementation for running
+  shell commands or Ruby code
+* sequences of commands using the same command abstraction as single commands.
+* a Configuration class and format for loading configuration files written in Ruby.
 
 ## Why?
-We've been using the same things again and again and can't be bothered to code it anew every time.
 
-The command abstraction has been used the most, the Logger defaults and formatting the least.
+Some of the same things are used again and again and shouldn't be rewritten
+every time.
+
+The command abstraction is the primary and most used feature of this gem. The
+logger creation convenience method and the adjusted logger formatter are used
+the least.
 
 ## Dependencies
-The platform independence for shell commands is achieved with the help of the [systemu](https://github.com/ahoward/systemu) gem.
 
-Everything else is pure Ruby.
+The platform independence for shell command execution is achieved with the
+help of the [systemu](https://github.com/ahoward/systemu) gem.
+
+Everything else is written in pure Ruby.
 
 ## Install
 

--- a/README.txt
+++ b/README.txt
@@ -1,12 +1,14 @@
-patir http://patir.rubyforge.org
+= patir http://patir.rubyforge.org
+
 == DESCRIPTION:
   
 patir provides code to enable project automation tasks:
 
-* A logging format for ruby's built-in Logger
-* A command abstraction with a platform independent implementation for running shell commands and ruby code
-* Command sequences using the same command abstraction as single commands.
-* Configuration format for configuration files written in ruby.
+* an adjusted logging format for the built-in logger of Ruby
+* a command abstraction with a platform independent implementation for running
+  shell commands or Ruby code
+* sequences of commands using the same command abstraction as single commands.
+* a Configuration class and format for loading configuration files written in Ruby.
 
 == INSTALL:
 
@@ -14,7 +16,7 @@ patir provides code to enable project automation tasks:
 
 == LICENSE:
 
-The MIT License)
+(The MIT License)
 
 Copyright (c) 2007-2012 Vassilis Rizopoulos
 

--- a/lib/patir/base.rb
+++ b/lib/patir/base.rb
@@ -2,7 +2,21 @@
 
 require 'logger'
 
-#This is the base module of the Patir system. It contains some usefull helper methods used by all child projects.
+##
+# The base module of the Patir gem
+#
+# This module contains a collection of classes, methods and modules useful for
+# other projects, the most relevant ones being:
+#
+# * Command - mix-in for any class representing an executable command
+#   * RubyCommand - class to execute a Ruby code snippet as a command
+#   * ShellCommand - class to execute shell commands in a platform independent
+#     manner
+# * CommandSequence - class holding and allowing the sequential execution of
+#   series of commands
+# * Configurator - class allowing to write configuration files as Ruby code and
+#   load/parse them conveniently
+# * Version - version information of this gem
 module Patir
   ##
   # Version information of the Patir gem

--- a/lib/patir/base.rb
+++ b/lib/patir/base.rb
@@ -1,41 +1,79 @@
-#  Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
+# Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
+
 require 'logger'
+
 #This is the base module of the Patir system. It contains some usefull helper methods used by all child projects.
 module Patir
-  #The Patir version used
+  ##
+  # Version information of the Patir gem
   module Version
+    ##
+    # The major version of the Patir gem
     MAJOR=0
+    ##
+    # The minor version of the Patir gem
     MINOR=9
+    ##
+    # The tiny version of the Patir gem
     TINY=0
+    ##
+    # The version information of the Patir gem as a string
     STRING=[ MAJOR, MINOR, TINY ].join( "." )  	
   end
-  #Error thrown usually in initialize methods when missing required parameters
-  #from the initialization hash.
+
+  ##
+  # Exception which is being raised if methods lack required arguments
+  #
+  # Currently this is thrown by ShellCommand only. It's thrown in case the
+  # +params+ hash passed to the initialize method of ShellCommand lacks a +:cmd+
+  # key.
   class ParameterException<RuntimeError
   end
   
+  ##
+  # Modified version of the default log message formatter of Ruby
   class PatirLoggerFormatter<Logger::Formatter
+    ##
+    # Format string defining the format of the created log messages
     Format="[%s] %5s: %s\n"
+
+    ##
+    # Initialize a new PatirLoggerFormatter instance
     def initialize
       @datetime_format="%Y%m%d %H:%M:%S"
     end
     
+    ##
+    # Create and return a log message representing the passed in arguments
+    #
+    # * +severity+ - a value representing the severity of the to be logged
+    #   message
+    # * +time+ - an instance of the Time class giving the time of the log
+    #   message
+    # * +progname+ - _unused_
+    # * +msg+ - the actual message to be logged
     def call severity, time, progname, msg
       Format % [format_datetime(time), severity,
         msg2str(msg)]
     end
   end
-  #Just making Logger usage easier
+
+  ##
+  # Convenience method for quickly setting up a logger
   #
-  #This is for use on top level scripts.
+  # This method allows setting up a logger with sane defaults with a one-liner
+  # and returns the new instance.
   #
-  #It creates a logger just as we want it.
-  #
-  #mode can be
-  # :mute to set the level to FATAL
-  # :silent to set the level to WARN
-  # :debug to set the level to DEBUG. Debug is set also if $DEBUG is true.
-  #The default logger level is INFO
+  # * +filename+ - a string representing of the path to the file which the log
+  #   shall be written to or an +IO+ object. If +nil+ the log is written to
+  #   +stdout+.
+  # * +mode+ - sets the log level and defaults to +Logger::INFO+ if +nil+. If
+  #   $DEBUG is set +Logger::DEBUG+ is forced in any case. Otherwise the
+  #   following arguments are valid:
+  #   * any of the +Logger::Severity+ values
+  #   * +:debug+ - to set the log level to +Logger::DEBUG+
+  #   * +:mute+ - to set the log level to +Logger::FATAL+
+  #   * +:silent+ - to set the log level to +Logger::WARN+
   def self.setup_logger(filename=nil,mode=nil)
     if filename
       logger=Logger.new(filename) 

--- a/lib/patir/configuration.rb
+++ b/lib/patir/configuration.rb
@@ -1,43 +1,86 @@
-#  Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
+# Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
 
 require 'patir/base'
+
 module Patir
-  #This exception is thrown when encountering a configuration error
+  ##
+  # Exception which is being thrown upon errors while loading a configuration
+  # file
+  #
+  # This may be caused e.g. by an invalid syntax of the configuration file or
+  # unknown configuration directives within it.
   class ConfigurationException<RuntimeError
   end
   
-  #Configurator is the base class for all the Patir configuration classes.
+  ##
+  # Configurator is intended as a base class for classes handling configuration
+  # files
   # 
-  #The idea behind the configurator is that the developer creates a module that contains as methods
-  #all the configuration directives.
-  #He then derives a class from Configurator and includes the directives module. 
-  #The Configurator loads the configuration file and evals it with itself as context (variable configuration), so the directives become methods in the configuration file:
-  # configuration.directive="some value"
-  # configuration.other_directive={:key=>"way to group values together",:other_key=>"omg"}
+  # The idea behind the Configurator class is that the developer creates a
+  # module that contains methods for all the configuration directives. Then a
+  # class can be derived from Configurator which includes the module with the
+  # directives.
   #
-  #The Configurator instance contains all the configuration data.
-  #Configurator#configuration method is provided as a post-processing step. It should be overriden to return the configuration data in the desired format and perform any overall validation steps (single element validation steps should be done in the directives module).
-  #==Example
-  # module SimpleConfiguration
-  #   def name= tool_name
-  #     raise Patir::ConfigurationException,"Inappropriate language not allowed" if tool_name=="@#!&@&$}"
-  #     @name=tool_name
-  #   end
-  # end
+  # The Configurator loads the configuration file and evals it with itself as
+  # context (variable configuration), so the directives become methods in the
+  # configuration file:
+  #
+  #     configuration.directive = "some value"
+  #     configuration.other_directive = { :key => "way to group values together",
+  #                                       :other_key=>"omg" }
+  #
+  # The Configurator instance then contains all the configuration data.
+  #
+  # The #configuration method is provided as a post-processing step. It should
+  # be overridden to return the configuration data in the desired format and
+  # perform any overall validation steps (single element validation steps should
+  # be done in the methods of the directives module).
+  #
+  # == Example
+  #
+  #     module SimpleConfiguration
+  #       def name=(tool_name)
+  #         raise Patir::ConfigurationException, \
+  #               "Inappropriate language not allowed" if tool_name == "@#!&@&$}"
+  #         @name = tool_name
+  #       end
+  #     end
   #   
-  # class SimpleConfigurator
-  #   include SimpleConfiguration
+  #     class SimpleConfigurator
+  #       include SimpleConfiguration
   #     
-  #   def configuration
-  #     return @name
-  #   end
-  # end
-  #The configuration file would then be 
-  # configuration.name="really polite name"
-  #To use it you would do
-  # cfg=SimpleConfigurator.new("config.cfg").configuration
+  #       def configuration
+  #         return @name
+  #       end
+  #     end
+  #
+  # The configuration file would then be:
+  #
+  #     configuration.name = "really polite name"
+  #
+  # It could then be used like:
+  #
+  #     cfg = SimpleConfigurator.new("config.cfg").configuration
   class Configurator
-    attr_reader :logger,:config_file,:wd
+    ##
+    # The main configuration file from which configuration loading started
+    attr_reader :config_file
+    ##
+    # An optional logger writing information about loaded files and errors if
+    # set
+    attr_reader :logger
+    ##
+    # The current working directory the Configurator instance is currently
+    # loading from
+    attr_reader :wd
+
+    ##
+    # Initialize a new Configurator instance
+    #
+    # * +config_file+ - the main (i.e root) configuration file which shall be
+    #   loaded
+    # * +logger+ - an optional logger which will log informational and debug
+    #   information if given
     def initialize config_file,logger=nil
       @logger=logger
       @logger||=Patir.setup_logger
@@ -45,24 +88,41 @@ module Patir
       load_configuration(@config_file)
     end
     
-    #Returns self. This should be overriden in the actual implementations
+    ##
+    # Returns self
+    #
+    # This can and/or should be overriden in the actual implementations (e.g. to
+    # conduct verification)
     def configuration
       return self
     end
     
-    #Loads the configuration from a file
+    ##
+    # Loads the configuration from a file
     #
-    #Use this to chain configuration files together
-    #==Example
-    #Say you have on configuration file "first.cfg" that contains all the generic directives and several others that change only one or two things. 
+    # This method can be used to chain configuration files together.
     #
-    #You can 'include' the first.cfg file in the other configurations with
-    # configuration.load_from_file("first.cfg")
+    # == Example
+    #
+    # If there is a configuration file +first.cfg+ that contains generic
+    # directives and there are several specific ones adjusting minor options.
+    # These specific files could "include" the general one in the following way:
+    #
+    #     configuration.load_from_file("first.cfg")
     def load_from_file filename
       fnm = File.exist?(filename) ? filename : File.join(@wd,filename)
       load_configuration(fnm)
     end
+
     private
+
+    ##
+    # Load the given configuration file
+    #
+    # This reads the entire file, changes the current working directory to the
+    # directory containing the file (to make relative references to other
+    # configuration files work) and then evaluates the file with the instance
+    # itself as context.
     def load_configuration filename
       begin 
         cfg_txt=File.read(filename)


### PR DESCRIPTION
This PR raises the documentation coverage of patir to 100%. Additionally the language of the documentation comments has been unified to generally relying on passive language instead of addressing the reader directly sometimes.

Since future pull requests will change great deals of code (e.g. unifying the formatting) this change has been made before to have the documentation strings as additional hooks to aid in avoiding merge conflicts and improve the readability of diffs.