### PR TITLE
Introduce RuboCop as development dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,35 @@
+---
+
+Metrics/AbcSize:
+  Max: 20
+Metrics/BlockLength:
+  Max: 120
+Layout/LineLength:
+  Max: 200
+Metrics/MethodLength:
+  Max: 25
+Style/AsciiComments:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+Style/NumericLiterals:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/RedundantReturn:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+AllCops:
+  Exclude:
+    - "out/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ group :development do
   gem "hoe", "~>3.22.3", :require => false
   gem "minitest", "~>5.14.3", :require => false
   gem "rdoc", "~>6.3.0", :require => false
+  gem "rubocop", "~>1.11.0", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     hoe (3.22.3)
       rake (>= 0.8, < 15.0)
     minitest (5.14.3)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
     rake (13.0.3)
     rdoc (6.3.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.4)
+    rubocop (1.11.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
     systemu (2.6.5)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   java
@@ -17,6 +37,7 @@ DEPENDENCIES
   hoe (~> 3.22.3)
   minitest (~> 5.14.3)
   rdoc (~> 6.3.0)
+  rubocop (~> 1.11.0)
   systemu (~> 2.6)
 
 BUNDLED WITH


### PR DESCRIPTION
This PR introduces _RuboCop_ as an additional development dependency. A RuboCop configuration file with the most essential preferences of Vassilis is added too.

The actual adjustment of the formatting will be done in subsequent PRs.