### PR TITLE
Review, format and adjust base.rb

### DIFF
--- a/lib/patir/base.rb
+++ b/lib/patir/base.rb
@@ -1,6 +1,8 @@
 # Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
 
-require 'logger'
+# frozen_string_literal: true
+
+require "logger"
 
 ##
 # The base module of the Patir gem
@@ -23,16 +25,16 @@ module Patir
   module Version
     ##
     # The major version of the Patir gem
-    MAJOR=0
+    MAJOR = 0
     ##
     # The minor version of the Patir gem
-    MINOR=9
+    MINOR = 9
     ##
     # The tiny version of the Patir gem
-    TINY=0
+    TINY = 0
     ##
     # The version information of the Patir gem as a string
-    STRING=[ MAJOR, MINOR, TINY ].join( "." )  	
+    STRING = [MAJOR, MINOR, TINY].join(".")
   end
 
   ##
@@ -41,22 +43,24 @@ module Patir
   # Currently this is thrown by ShellCommand only. It's thrown in case the
   # +params+ hash passed to the initialize method of ShellCommand lacks a +:cmd+
   # key.
-  class ParameterException<RuntimeError
+  class ParameterException < RuntimeError
   end
-  
+
   ##
   # Modified version of the default log message formatter of Ruby
-  class PatirLoggerFormatter<Logger::Formatter
+  class PatirLoggerFormatter < Logger::Formatter
     ##
     # Format string defining the format of the created log messages
-    Format="[%s] %5s: %s\n"
+    FORMAT = "[%s] %5s: %s\n"
 
     ##
     # Initialize a new PatirLoggerFormatter instance
     def initialize
-      @datetime_format="%Y%m%d %H:%M:%S"
+      super
+
+      @datetime_format = "%Y%m%d %H:%M:%S"
     end
-    
+
     ##
     # Create and return a log message representing the passed in arguments
     #
@@ -66,9 +70,8 @@ module Patir
     #   message
     # * +progname+ - _unused_
     # * +msg+ - the actual message to be logged
-    def call severity, time, progname, msg
-      Format % [format_datetime(time), severity,
-        msg2str(msg)]
+    def call(severity, time, _progname, msg)
+      format(FORMAT, format_datetime(time), severity, msg2str(msg))
     end
   end
 
@@ -88,19 +91,18 @@ module Patir
   #   * +:debug+ - to set the log level to +Logger::DEBUG+
   #   * +:mute+ - to set the log level to +Logger::FATAL+
   #   * +:silent+ - to set the log level to +Logger::WARN+
-  def self.setup_logger(filename=nil,mode=nil)
+  def self.setup_logger(filename = nil, mode = nil)
     if filename
-      logger=Logger.new(filename) 
+      logger = Logger.new(filename)
     else
-      logger=Logger.new($stdout)
+      logger = Logger.new($stdout)
     end
-    logger.level=Logger::INFO
-    logger.level=mode if [Logger::DEBUG, Logger::FATAL, Logger::INFO, Logger::UNKNOWN, Logger::WARN].member?(mode)
-    logger.level=Logger::FATAL if mode==:mute
-    logger.level=Logger::WARN if mode==:silent
-    logger.level=Logger::DEBUG if mode==:debug || $DEBUG
-    logger.formatter=PatirLoggerFormatter.new
-    #logger.datetime_format="%Y%m%d %H:%M:%S"
+    logger.level = Logger::INFO
+    logger.level = mode if [Logger::DEBUG, Logger::FATAL, Logger::INFO, Logger::UNKNOWN, Logger::WARN].member?(mode)
+    logger.level = Logger::FATAL if mode == :mute
+    logger.level = Logger::WARN if mode == :silent
+    logger.level = Logger::DEBUG if mode == :debug || $DEBUG
+    logger.formatter = PatirLoggerFormatter.new
     return logger
   end
 end

--- a/lib/patir/base.rb
+++ b/lib/patir/base.rb
@@ -95,7 +95,7 @@ module Patir
       logger=Logger.new($stdout)
     end
     logger.level=Logger::INFO
-    logger.level=mode if [Logger::INFO,Logger::FATAL,Logger::WARN,Logger::DEBUG].member?(mode)
+    logger.level=mode if [Logger::DEBUG, Logger::FATAL, Logger::INFO, Logger::UNKNOWN, Logger::WARN].member?(mode)
     logger.level=Logger::FATAL if mode==:mute
     logger.level=Logger::WARN if mode==:silent
     logger.level=Logger::DEBUG if mode==:debug || $DEBUG

--- a/lib/patir/base.rb
+++ b/lib/patir/base.rb
@@ -92,7 +92,7 @@ module Patir
     if filename
       logger=Logger.new(filename) 
     else
-      logger=Logger.new(STDOUT)
+      logger=Logger.new($stdout)
     end
     logger.level=Logger::INFO
     logger.level=mode if [Logger::INFO,Logger::FATAL,Logger::WARN,Logger::DEBUG].member?(mode)

--- a/test/test_patir_base.rb
+++ b/test/test_patir_base.rb
@@ -1,3 +1,5 @@
+# Copyright (c) 2012-2021 Vassilis Rizopoulos. All rights reserved.
+
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
@@ -5,23 +7,109 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
 require "minitest/autorun"
 require "patir/base"
 
+##
+# Verify the basic functionality contained directly in the Patir module
 class TestBase < Minitest::Test
+  ##
+  # Path to temporary file used for logging tests
   TEMP_LOG = "temp.log"
+
+  ##
+  # Clean-up actions after completed tests
   def teardown
-    # clean up
     File.delete(TEMP_LOG) if File.exist?(TEMP_LOG)
   end
 
-  # This is not actually testing anything meaningfull but can be expanded when we learn more about
-  # the logger
-  def test_setup_logger
+  ##
+  # Verify that the $DEBUG global is correctly handled on initialization
+  def test_setup_logger_debug_global
+    debug_prev = $DEBUG
+    $DEBUG = false
+    logger = Patir.setup_logger(nil, Logger::FATAL)
+    assert_equal(Logger::FATAL, logger.level)
+    $DEBUG = true
+    logger = Patir.setup_logger(nil, Logger::FATAL)
+    assert_equal(Logger::DEBUG, logger.level)
+    $DEBUG = debug_prev
+  end
+
+  ##
+  # Verify correct setup of the logger with default arguments
+  def test_setup_logger_call_with_defaults
     logger = Patir.setup_logger
-    refute_nil(logger)
-    logger = Patir.setup_logger(nil, :silent)
-    refute_nil(logger)
-    logger = Patir.setup_logger("temp.log", :silent)
-    refute_nil(logger)
+    assert_kind_of(Patir::PatirLoggerFormatter, logger.formatter)
+    assert_equal(Logger::INFO, logger.level)
+  end
+
+  ##
+  # Verify that the log output is being handled correctly
+  def test_setup_logger_file_handling
+    logger = Patir.setup_logger(nil)
+    assert_kind_of(Logger, logger)
+    refute(File.exist?(TEMP_LOG), "Log file created")
+    logger = Patir.setup_logger("temp.log")
+    assert_kind_of(Logger, logger)
     assert(File.exist?(TEMP_LOG), "Log file not created")
     logger.close
+  end
+
+  ##
+  # Verify that loglevels are set correctly
+  def test_setup_logger_loglevels
+    params = [
+      # Check default value
+      { :arg => nil, :lvl => Logger::INFO },
+      # Check all Logger::Severity values
+      { :arg => Logger::DEBUG, :lvl => Logger::DEBUG },
+      { :arg => Logger::FATAL, :lvl => Logger::FATAL },
+      { :arg => Logger::INFO, :lvl => Logger::INFO },
+      { :arg => Logger::UNKNOWN, :lvl => Logger::UNKNOWN },
+      { :arg => Logger::WARN, :lvl => Logger::WARN },
+      # Check the three handled symbols
+      { :arg => :mute, :lvl => Logger::FATAL },
+      { :arg => :silent, :lvl => Logger::WARN },
+      { :arg => :debug, :lvl => Logger::DEBUG }
+    ]
+    params.each do |param|
+      logger = Patir.setup_logger(nil, param[:arg])
+      assert_equal(param[:lvl], logger.level)
+    end
+  end
+end
+
+##
+# Verify functionality of the Patir::PatirLoggerFormatter class
+class TestPatirLoggerFormatter < Minitest::Test
+  ##
+  # Check formatting with a few random message and severity combinations
+  def test_formatting
+    formatter = Patir::PatirLoggerFormatter.new
+
+    assert_match(/^\[\d{8} \d{2}:\d{2}:\d{2}\]\s+\d+: Some vain information\n$/,
+                 formatter.call(Logger::DEBUG, Time.now, "IGNORED",
+                                "Some vain information"))
+    assert_match(/^\[\d{8} \d{2}:\d{2}:\d{2}\]\s+\d+: Some bad information\n$/,
+                 formatter.call(Logger::FATAL, Time.now, "IGNORED",
+                                "Some bad information"))
+    assert_match(/^\[\d{8} \d{2}:\d{2}:\d{2}\]\s+\d+: Some information\n$/,
+                 formatter.call(Logger::INFO, Time.now, "IGNORED",
+                                "Some information"))
+  end
+
+  ##
+  # Verify that new Patir::PatirLoggerFormatter instances are initialized
+  # correctly
+  def test_initialization
+    formatter = Patir::PatirLoggerFormatter.new
+    assert_equal("%Y%m%d %H:%M:%S", formatter.datetime_format)
+  end
+end
+
+##
+# Verify functionality of the Patir::Version module
+class TestVersion < Minitest::Test
+  # Verify that the string representation is properly created
+  def test_string_representation
+    assert_equal("0.9.0", Patir::Version::STRING)
   end
 end

--- a/test/test_patir_base.rb
+++ b/test/test_patir_base.rb
@@ -1,25 +1,27 @@
-$:.unshift File.join(File.dirname(__FILE__),"..","lib")
-require "minitest/autorun"
-require 'patir/base.rb'
+# frozen_string_literal: true
 
-class TestBase<Minitest::Test
-  TEMP_LOG="temp.log"
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
+require "minitest/autorun"
+require "patir/base"
+
+class TestBase < Minitest::Test
+  TEMP_LOG = "temp.log"
   def teardown
-    #clean up 
+    # clean up
     File.delete(TEMP_LOG) if File.exist?(TEMP_LOG)
   end
-  
-  #This is not actually testing anything meaningfull but can be expanded when we learn more about 
-  #the logger
+
+  # This is not actually testing anything meaningfull but can be expanded when we learn more about
+  # the logger
   def test_setup_logger
-    logger=Patir.setup_logger
+    logger = Patir.setup_logger
     refute_nil(logger)
-    logger=Patir.setup_logger(nil,:silent)
+    logger = Patir.setup_logger(nil, :silent)
     refute_nil(logger)
-    logger=Patir.setup_logger("temp.log",:silent)
+    logger = Patir.setup_logger("temp.log", :silent)
     refute_nil(logger)
     assert(File.exist?(TEMP_LOG), "Log file not created")
     logger.close
   end
-  
 end


### PR DESCRIPTION
This has only two very minor functional changes:
- the default logger created by `setup_logger` has been switched from using `STDOUT` to `$stdout`. This should have fixed an issue (and seems anyhow to be the up-to-date way) with Minitest not being able to capture `stdout`. Unfortunately neither way worked, but I still left it like that
- `Logger::UNKNOWN` severity is now being handled by `setup_logger` instead of being ignored and defaulting to `Logger::INFO`
The rest is mainly increasing test coverage and formatting done by _RuboCop_.