### PR TITLE
Lift all dependencies to current state again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source "https://rubygems.org"
-gem 'systemu',"~>2.6"
+
+gem "systemu", "~>2.6.5"
 
 group :development do
   gem "hoe", "~>3.22.3", :require => false
-  gem "minitest", "~>5.14.3", :require => false
+  gem "minitest", "~>5.14.4", :require => false
   gem "rdoc", "~>6.3.0", :require => false
-  gem "rubocop", "~>1.11.0", :require => false
+  gem "rubocop", "~>1.12.0", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.2)
     hoe (3.22.3)
       rake (>= 0.8, < 15.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -13,7 +13,7 @@ GEM
     rdoc (6.3.0)
     regexp_parser (2.1.1)
     rexml (3.2.4)
-    rubocop (1.11.0)
+    rubocop (1.12.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -35,10 +35,10 @@ PLATFORMS
 
 DEPENDENCIES
   hoe (~> 3.22.3)
-  minitest (~> 5.14.3)
+  minitest (~> 5.14.4)
   rdoc (~> 6.3.0)
-  rubocop (~> 1.11.0)
-  systemu (~> 2.6)
+  rubocop (~> 1.12.0)
+  systemu (~> 2.6.5)
 
 BUNDLED WITH
-   1.14.3
+   2.2.15


### PR DESCRIPTION
This PR doesn't really change anything. Most notable is the update of _Bundler_ from `1.14.3` to `2.2.15`. This change is done to streamline _patir_ with soon starting adjustments to rutema.