### PR TITLE
Review, format and adjust command.rb

### DIFF
--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -1,5 +1,6 @@
 # Copyright (c) 2007-2012 Vassilis Rizopoulos. All rights reserved.
 
+require "English"
 require 'observer'
 require 'fileutils'
 require 'systemu'
@@ -54,7 +55,7 @@ module Patir
     # Returns the command's alias name
     def name
       # Initialize nil values to something meaningful
-      @name||=""
+      @name ||= ""
       return @name
     end
 
@@ -62,7 +63,7 @@ module Patir
     # Returns the output of the command
     def output
       # Initialize nil values to something meaningful
-      @output||=""
+      @output ||= ""
       return @output
     end
 
@@ -70,7 +71,7 @@ module Patir
     # Returns the error output for the command
     def error
       # Initialize nil values to something meaningful
-      @error||=""
+      @error ||= ""
       return @error
     end
 
@@ -78,7 +79,7 @@ module Patir
     # Returns a backtrace for the command
     def backtrace
       # Initialize nil values to something meaningful
-      @backtrace||=""
+      @backtrace ||= ""
       return @backtrace
     end
 
@@ -86,14 +87,15 @@ module Patir
     # Returns the execution time (duration) for the command
     def exec_time
       # Initialize nil values to something meaningful
-      @exec_time||=0
+      @exec_time ||= 0
       return @exec_time
     end
 
     ##
     # Returns true if the command has finished successfully
     def success?
-      return true if self.status==:success
+      return true if status == :success
+
       return false
     end
 
@@ -107,9 +109,9 @@ module Patir
     # Execute the command and return the status of the command
     #
     # This method should be overridden by classes which include Command.
-    def run context=nil
-      @status=:success
-      return self.status
+    def run(_context = nil)
+      @status = :success
+      return status
     end
 
     ##
@@ -118,11 +120,11 @@ module Patir
     # This method should be called if the class shall be reset to a state as if
     # the command never got executed.
     def reset
-      @backtrace=""
-      @exec_time=0
-      @output=""
-      @error=""
-      @status=:not_executed
+      @backtrace = ""
+      @exec_time = 0
+      @output = ""
+      @error = ""
+      @status = :not_executed
     end
 
     ##
@@ -130,15 +132,16 @@ module Patir
     #
     # This is an alias for #run?.
     def executed?
-      return false if self.status==:not_executed
+      return false if status == :not_executed
+
       return true
     end
 
     ##
     # Returns the command's status
     def status
-      #initialize nil values to something meaningful
-      @status||=:not_executed
+      # Initialize nil values to something meaningful
+      @status ||= :not_executed
       return @status
     end
   end
@@ -709,14 +712,13 @@ module Patir
     #   shall be executed (defaults to the current directory if +nil+)
     # * +block+ - the block which shall be executed upon invocation of the #run
     #   method
-    def initialize name,working_directory=nil,&block
-      @name=name
-      @working_directory=working_directory||"."
-      if block_given?
-        @cmd=block 
-      else
-        raise "You need to provide a block"
-      end
+    def initialize(name, working_directory = nil, &block)
+      @name = name
+      @working_directory = working_directory || "."
+
+      raise "A block must be provided to RubyCommand upon initialization" unless block_given?
+
+      @cmd = block
     end
 
     ##
@@ -724,25 +726,25 @@ module Patir
     #
     # This sets the internal @status variable according to the result of the
     # execution of the block.
-    def run context=nil
-      @context=context
-      @error=""
-      @output=""
-      @backtrace=""
+    def run(context = nil)
+      @context = context
+      @error = ""
+      @output = ""
+      @backtrace = ""
       begin
-        t1=Time.now
+        t1 = Time.now
         Dir.chdir(@working_directory) do
           @cmd.call(self)
-          @status=:success
+          @status = :success
         end
       rescue StandardError
-        @error<<"\n#{$!.message}"
-        @backtrace=$@
-        @status=:error
+        @error << "\n#{$ERROR_INFO.message}"
+        @backtrace = $ERROR_POSITION
+        @status = :error
       ensure
-        @exec_time=Time.now-t1
+        @exec_time = Time.now - t1
       end
-      @context=nil
+      @context = nil
       return @status
     end
   end

--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -725,7 +725,6 @@ module Patir
     # This sets the internal @status variable according to the result of the
     # execution of the block.
     def run context=nil
-      @run=true
       @context=context
       @error=""
       @output=""

--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -300,28 +300,28 @@ module Patir
     #
     # * +name+ - a descriptive name
     # * +sequence_runner+ - name of the runner executing the sequence
-    def initialize name,sequence_runner=""
-      @name=name
-      @steps||=Array.new
-      @sequence_runner=sequence_runner
-      #intialize the status for the currently active build (not executed)
+    def initialize(name, sequence_runner = "")
+      @name = name
+      @steps ||= []
+      @sequence_runner = sequence_runner
+      # Intialize the status for the currently active build (not executed)
       reset
     end
 
     ##
     # Set the internal +sequence_runner+ attribute and update the internally
     # held CommandSequenceStatus instance
-    def sequence_runner=name
-      @sequence_runner=name
-      @state.sequence_runner=name
+    def sequence_runner=(name)
+      @sequence_runner = name
+      @state.sequence_runner = name
     end
 
     ##
     # Set the internal +sequence_id+ attribute and update the internally held
     # CommandSequenceStatus instance
-    def sequence_id=name
-      @sequence_id=name
-      @state.sequence_id=name
+    def sequence_id=(name)
+      @sequence_id = name
+      @state.sequence_id = name
     end
 
     ##
@@ -329,57 +329,57 @@ module Patir
     #
     # This will run all step instances in the sequence observing the exit
     # strategies of each command on warnings or failures.
-    def run context=nil
-      #set the start time
-      @state.start_time=Time.now
-      #reset the stop time
-      @state.stop_time=nil
-      #we started running, lets tell the world
-      @state.status=:running
-      notify(:sequence_status=>@state)
-      #we are optimistic
-      running_status=:success
-      #but not that much
-      running_status=:warning if @steps.empty?
-      #execute the steps in sequence
+    def run(context = nil)
+      # Set the start time
+      @state.start_time = Time.now
+      # Reset the stop time
+      @state.stop_time = nil
+      # Running started, tell the world
+      @state.status = :running
+      notify(:sequence_status => @state)
+      # Be optimistic
+      running_status = :success
+      # But not that much
+      running_status = :warning if @steps.empty?
+      # Execute the steps in sequence
       @steps.each do |step|
-        #the step is running, tell the world
-        @state.step=step
-        step.status=:running
-        notify(:sequence_status=>@state)
-        #run it, get the result and notify
-        result=step.run(context)
-        @state.step=step
-        step.status=:running
-        notify(:sequence_status=>@state)
-        #evaluate the results' effect on execution status at the end
+        # The step is running, tell the world
+        @state.step = step
+        step.status = :running
+        notify(:sequence_status => @state)
+        # Run it, get the result and notify
+        result = step.run(context)
+        @state.step = step
+        step.status = :running
+        notify(:sequence_status => @state)
+        # Evaluate the results' effect on the execution status at the end
         case result
         when :success
-          #everything is fine, continue
+          # Everything is fine, continue
         when :error
-          #this will be the final status
-          running_status=:error
-          #stop if we fail on error
-          if :fail_on_error==step.strategy
-            @state.status=:error
-            break 
+          # This will be the final status
+          running_status = :error
+          # Stop if we fail on error
+          if :fail_on_error == step.strategy
+            @state.status = :error
+            break
           end
         when :warning
-          #a previous failure overrides a warning
-          running_status=:warning unless :error==running_status
-          #escalate this to a failure if the strategy says so
-          running_status=:error if :flunk_on_warning==step.strategy
-          #stop if we fail on warning
-          if :fail_on_warning==step.strategy
-            @state.status=:error
-            break 
+          # A previous failure overrides a warning
+          running_status = :warning unless :error == running_status
+          # Escalate this to a failure if the strategy says so
+          running_status = :error if :flunk_on_warning == step.strategy
+          # Stop if we fail on warning
+          if :fail_on_warning == step.strategy
+            @state.status = :error
+            break
           end
         end
-      end#each step
-      #we finished
-      @state.stop_time=Time.now
-      @state.status=running_status
-      notify(:sequence_status=>@state)
+      end
+      # We finished
+      @state.stop_time = Time.now
+      @state.status = running_status
+      notify(:sequence_status => @state)
     end
 
     ##
@@ -395,20 +395,20 @@ module Patir
     # * +:fail_on_warning+ - CommandSequence terminates on warnings of the step
     # * +:flunk_on_warning+ - CommandSequence is flagged as failed on warning in
     #   this step but continues
-    def add_step step,exit_strategy=:fail_on_error
-      #duplicate the command
-      bstep=step.dup
-      #reset it
+    def add_step(step, exit_strategy = :fail_on_error)
+      # duplicate the command
+      bstep = step.dup
+      # reset it
       bstep.reset
-      #set the extended attributes
-      bstep.number=@steps.size
-      exit_strategy = :fail_on_error unless [:flunk_on_error,:fail_on_warning,:flunk_on_warning].include?(exit_strategy)
-      bstep.strategy=exit_strategy
-      #add it to the lot
-      @steps<<bstep
-      #add it to status as well
-      @state.step=bstep
-      notify(:sequence_status=>@state)
+      # set the extended attributes
+      bstep.number = @steps.size
+      exit_strategy = :fail_on_error unless [:flunk_on_error, :fail_on_warning, :flunk_on_warning].include?(exit_strategy)
+      bstep.strategy = exit_strategy
+      # add it to the lot
+      @steps << bstep
+      # add it to status as well
+      @state.step = bstep
+      notify(:sequence_status => @state)
       return bstep
     end
 
@@ -418,22 +418,22 @@ module Patir
     # This will set the status to +:not_executed+, reset all added steps and set
     # the start and end times to +nil+.
     def reset
-      #reset all the steps (stati and execution times)
-      @steps.each{|step| step.reset}
-      #reset the status
-      @state=CommandSequenceStatus.new(@name)
-      @steps.each{|step| @state.step=step}
-      @state.start_time=Time.now
-      @state.stop_time=nil
-      @state.sequence_runner=@sequence_runner
-      #tell the world
-      notify(:sequence_status=>@state)
+      # reset all the steps (stati and execution times)
+      @steps.each { |step| step.reset }
+      # reset the status
+      @state = CommandSequenceStatus.new(@name)
+      @steps.each { |step| @state.step = step }
+      @state.start_time = Time.now
+      @state.stop_time = nil
+      @state.sequence_runner = @sequence_runner
+      # tell the world
+      notify(:sequence_status => @state)
     end
 
     ##
     # Returns +true+ if the sequence finished its execution
-    def completed?  
-      return @state.completed? 
+    def completed?
+      return @state.completed?
     end
 
     ##
@@ -443,14 +443,14 @@ module Patir
     #
     #     <sequence_id>:<name> on <sequence_runner>, <step_qty> steps
     def to_s
-      "#{sequence_id}:#{:name} on #{@sequence_runner}, #{@steps.size} steps"
+      "#{sequence_id}:name on #{@sequence_runner}, #{@steps.size} steps"
     end
 
     private
 
     ##
     # Notify observers of changes
-    def notify *params
+    def notify(*params)
       changed
       notify_observers(*params)
     end

--- a/test/test_patir_command.rb
+++ b/test/test_patir_command.rb
@@ -1,6 +1,11 @@
-$:.unshift File.join(File.dirname(__FILE__),"..","lib")
+# Copyright (c) 2012-2021 Vassilis Rizopoulos. All rights reserved.
+
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
+
 require "minitest/autorun"
-require 'patir/command.rb'
+require "patir/command"
 
 class MockCommandObject
   include Patir::Command
@@ -8,93 +13,94 @@ end
 
 class MockCommandWarning
   include Patir::Command
-  def run context=nil
-    @status=:warning
+  def run(_context = nil)
+    @status = :warning
     return :warning
   end
 end
 
 class MockCommandError
   include Patir::Command
-  def run context=nil
-    @status=:error
+  def run(_context = nil)
+    @status = :error
     return :error
   end
 end
 
-class TestCommand<Minitest::Test
-  #tests the default values set by the module
+class TestCommand < Minitest::Test
+  # tests the default values set by the module
   def test_module
-    obj=MockCommandObject.new
-    assert_equal("",obj.backtrace)
-    assert_equal("",obj.name)
-    assert_equal(:not_executed,obj.status)
+    obj = MockCommandObject.new
+    assert_equal("", obj.backtrace)
+    assert_equal("", obj.name)
+    assert_equal(:not_executed, obj.status)
     assert(!obj.run?)
     assert(obj.run)
     assert(obj.run?)
-    assert_equal(:success,obj.status)
-    assert_equal("",obj.output)
-    assert_equal("",obj.error)
-    assert_equal(0,obj.exec_time)
+    assert_equal(:success, obj.status)
+    assert_equal("", obj.output)
+    assert_equal("", obj.error)
+    assert_equal(0, obj.exec_time)
     assert(obj.reset)
-    assert_equal(:not_executed,obj.status)
+    assert_equal(:not_executed, obj.status)
   end
 end
 
-class TestShellCommand<Minitest::Test
+class TestShellCommand < Minitest::Test
   include Patir
   def teardown
     Dir.delete("missing/") if File.exist?("missing/")
   end
-  #test the expected behaviour of a succesfull command
+
+  # test the expected behaviour of a succesfull command
   def test_echo
-    cmd=nil
-    assert(cmd=ShellCommand.new(:cmd=>"echo hello"))
-    assert_instance_of(ShellCommand,cmd)
+    assert(cmd = ShellCommand.new(:cmd => "echo hello"))
+    assert_instance_of(ShellCommand, cmd)
     assert(!cmd.run?)
     assert(!cmd.success?)
     assert(cmd.run)
     assert(cmd.run?)
     assert(cmd.success?)
-    assert_equal("hello",cmd.output.chomp)
-    assert_equal("",cmd.error)
-    assert_equal(:success,cmd.status)
+    assert_equal("hello", cmd.output.chomp)
+    assert_equal("", cmd.error)
+    assert_equal(:success, cmd.status)
   end
-  #test that error status is reported correctly, by testing a command that fails.
+
+  # test that error status is reported correctly, by testing a command that fails.
   def test_error
-    cmd=nil
-    assert(cmd=ShellCommand.new(:cmd=>"cd /missing"))
+    assert(cmd = ShellCommand.new(:cmd => "cd /missing"))
     assert(!cmd.run?)
     assert(!cmd.success?)
     assert(cmd.run)
     assert(cmd.run?)
     assert(!cmd.success?)
-    assert_equal(:error,cmd.status)
+    assert_equal(:error, cmd.status)
   end
-  #when passed a wroking directory, the command should change into that directory
+
+  # when passed a wroking directory, the command should change into that directory
   def test_cwd
-    cmd=nil
-    assert(cmd=ShellCommand.new(:cmd=>"echo", :working_directory=>"missing/"))
+    assert(cmd = ShellCommand.new(:cmd => "echo", :working_directory => "missing/"))
     assert(cmd.run)
     assert(cmd.success?)
   end
-  
-  #when the working directory is missing, it should be created when the command is run
+
+  # when the working directory is missing, it should be created when the command is run
   def test_missing_cwd
-    cmd=nil
-    assert(cmd=ShellCommand.new(:cmd=>"echo hello", :working_directory=>"missing/"))
-    assert_instance_of(ShellCommand,cmd)
-    assert_equal(:success,cmd.run)
+    assert(cmd = ShellCommand.new(:cmd => "echo hello", :working_directory => "missing/"))
+    assert_instance_of(ShellCommand, cmd)
+    assert_equal(:success, cmd.run)
     assert(cmd.success?)
     assert(File.exist?("missing/"))
   end
-  #an exception should be thrown when :cmd is nil
+
+  # an exception should be thrown when :cmd is nil
   def test_missing_cmd
-    assert_raises(ParameterException){ShellCommand.new(:working_directory=>"missing/")}
+    assert_raises(ParameterException) { ShellCommand.new(:working_directory => "missing/") }
   end
-  #test with another program
+
+  # test with another program
   def test_ls
-    cmd=ShellCommand.new(:cmd=>"ls")
+    cmd = ShellCommand.new(:cmd => "ls")
     assert(!cmd.run?)
     assert(!cmd.success?)
     assert(cmd.run)
@@ -105,27 +111,29 @@ class TestShellCommand<Minitest::Test
       refute_equal("", cmd.error)
     end
   end
+
   def test_timeout
-    cmd=ShellCommand.new(:cmd=>"ruby -e 't=0;while t<10 do p t;t+=1;sleep 1 end '",:timeout=>1)
+    cmd = ShellCommand.new(:cmd => "ruby -e 't=0;while t<10 do p t;t+=1;sleep 1 end '", :timeout => 1)
     assert(cmd.run)
     assert(cmd.run?, "Should be marked as run")
-    assert(!cmd.success?,"Should not have been successful")
+    assert(!cmd.success?, "Should not have been successful")
     assert(!cmd.error.empty?, "There should be an error message")
-    #test also for an exit within the timeout
-    cmd=ShellCommand.new(:cmd=>"ruby -e 't=0;while t<1 do p t;t+=1;sleep 1 end '",:timeout=>4)
+    # test also for an exit within the timeout
+    cmd = ShellCommand.new(:cmd => "ruby -e 't=0;while t<1 do p t;t+=1;sleep 1 end '", :timeout => 4)
     assert(cmd.run)
     assert(cmd.run?, "Should be marked as run")
-    assert(cmd.success?,"Should have been successful")
+    assert(cmd.success?, "Should have been successful")
     assert(cmd.error.empty?, "There should be no error messages")
   end
+
   def test_missing_executable
-    cmd=ShellCommand.new(:cmd=>"bla")
+    cmd = ShellCommand.new(:cmd => "bla")
     assert(!cmd.run?)
     assert(!cmd.success?)
     assert(cmd.run)
     assert(!cmd.success?, "Should fail if the executable is missing")
 
-    cmd=ShellCommand.new(:cmd=>'"With spaces" and params')
+    cmd = ShellCommand.new(:cmd => '"With spaces" and params')
     assert(!cmd.run?)
     assert(!cmd.success?)
     assert(cmd.run)
@@ -133,123 +141,121 @@ class TestShellCommand<Minitest::Test
   end
 end
 
-class TestCommandSequence<Minitest::Test
+class TestCommandSequence < Minitest::Test
   include Patir
   def setup
-    @echo=ShellCommand.new(:cmd=>"echo hello")
-    @void=MockCommandObject.new
-    @error=MockCommandError.new
-    @warning=MockCommandWarning.new
+    @echo = ShellCommand.new(:cmd => "echo hello")
+    @void = MockCommandObject.new
+    @error = MockCommandError.new
+    @warning = MockCommandWarning.new
   end
-  
+
   def test_normal
-    seq=CommandSequence.new("test")
+    seq = CommandSequence.new("test")
     assert(seq.steps.empty?)
     refute_nil(seq.run)
     assert(!seq.state.success?)
-    assert_equal(:warning,seq.state.status)
+    assert_equal(:warning, seq.state.status)
     assert(seq.add_step(@echo))
     assert(seq.add_step(@void))
     refute_nil(seq.run)
     assert(seq.state.success?)
   end
-  
+
   def test_flunk_on_error
-    seq=CommandSequence.new("test")
+    seq = CommandSequence.new("test")
     assert(seq.steps.empty?)
-    check_step=nil
-    assert(check_step=seq.add_step(@echo,:flunk_on_error))
-    assert_equal(:flunk_on_error,check_step.strategy)
-    assert(seq.add_step(@error,:flunk_on_error))
-    assert(seq.add_step(@void,:flunk_on_error))
-    assert(:not_executed==seq.state.step_state(0)[:status])
-    assert(:not_executed==seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    assert(check_step = seq.add_step(@echo, :flunk_on_error))
+    assert_equal(:flunk_on_error, check_step.strategy)
+    assert(seq.add_step(@error, :flunk_on_error))
+    assert(seq.add_step(@void, :flunk_on_error))
+    assert_equal(:not_executed, seq.state.step_state(0)[:status])
+    assert_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
     refute_nil(seq.run)
     assert(!seq.state.success?)
-    #all three steps should have been run
-    assert(:not_executed!=seq.state.step_state(0)[:status])
-    assert(:not_executed!=seq.state.step_state(1)[:status])
-    assert(:not_executed!=seq.state.step_state(2)[:status])
+    # all three steps should have been run
+    refute_equal(:not_executed, seq.state.step_state(0)[:status])
+    refute_equal(:not_executed, seq.state.step_state(1)[:status])
+    refute_equal(:not_executed, seq.state.step_state(2)[:status])
   end
-  
+
   def test_fail_on_error
-    seq=CommandSequence.new("test")
+    seq = CommandSequence.new("test")
     assert(seq.steps.empty?)
     assert(seq.add_step(@echo))
-    check_step=nil
-    assert(check_step=seq.add_step(@error,:fail_on_error))
-    assert_equal(:fail_on_error,check_step.strategy)
+    assert(check_step = seq.add_step(@error, :fail_on_error))
+    assert_equal(:fail_on_error, check_step.strategy)
     assert(seq.add_step(@void))
-    assert(:not_executed==seq.state.step_state(0)[:status])
-    assert(:not_executed==seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    assert_equal(:not_executed, seq.state.step_state(0)[:status])
+    assert_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
     refute_nil(seq.run)
     assert(!seq.state.success?)
-    #only two steps should have been run
-    assert(:not_executed!=seq.state.step_state(0)[:status])
-    assert(:not_executed!=seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    # only two steps should have been run
+    refute_equal(:not_executed, seq.state.step_state(0)[:status])
+    refute_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
   end
-  
+
   def test_flunk_on_warning
-    seq=CommandSequence.new("test")
+    seq = CommandSequence.new("test")
     assert(seq.steps.empty?)
     assert(seq.add_step(@echo))
-    check_step=nil
-    assert(check_step=seq.add_step(@error,:flunk_on_warning))
-    assert_equal(:flunk_on_warning,check_step.strategy)
+    assert(check_step = seq.add_step(@error, :flunk_on_warning))
+    assert_equal(:flunk_on_warning, check_step.strategy)
     assert(seq.add_step(@void))
-    assert(:not_executed==seq.state.step_state(0)[:status])
-    assert(:not_executed==seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    assert_equal(:not_executed, seq.state.step_state(0)[:status])
+    assert_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
     refute_nil(seq.run)
     assert(!seq.state.success?)
-    #all three steps should have been run
-    assert(:not_executed!=seq.state.step_state(0)[:status])
-    assert(:not_executed!=seq.state.step_state(1)[:status])
-    assert(:not_executed!=seq.state.step_state(2)[:status])
+    # all three steps should have been run
+    refute_equal(:not_executed, seq.state.step_state(0)[:status])
+    refute_equal(:not_executed, seq.state.step_state(1)[:status])
+    refute_equal(:not_executed, seq.state.step_state(2)[:status])
   end
-  
+
   def test_fail_on_warning
-    seq=CommandSequence.new("test")
+    seq = CommandSequence.new("test")
     assert(seq.steps.empty?)
     assert(seq.add_step(@echo))
-    check_step=nil
-    assert(check_step=seq.add_step(@warning,:fail_on_warning))
-    assert_equal(:fail_on_warning,check_step.strategy)
+    assert(check_step = seq.add_step(@warning, :fail_on_warning))
+    assert_equal(:fail_on_warning, check_step.strategy)
     assert(seq.add_step(@void))
-    assert(:not_executed==seq.state.step_state(0)[:status])
-    assert(:not_executed==seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    assert_equal(:not_executed, seq.state.step_state(0)[:status])
+    assert_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
     refute_nil(seq.run)
     assert(!seq.state.success?)
-    #only two steps should have been run
-    assert(:not_executed!=seq.state.step_state(0)[:status])
-    assert(:not_executed!=seq.state.step_state(1)[:status])
-    assert(:not_executed==seq.state.step_state(2)[:status])
+    # only two steps should have been run
+    refute_equal(:not_executed, seq.state.step_state(0)[:status])
+    refute_equal(:not_executed, seq.state.step_state(1)[:status])
+    assert_equal(:not_executed, seq.state.step_state(2)[:status])
   end
 end
 
-class TestRubyCommand<Minitest::Test
+class TestRubyCommand < Minitest::Test
   include Patir
   def test_normal_ruby
-    cmd=RubyCommand.new("test"){sleep 1}
+    cmd = RubyCommand.new("test") { sleep 1 }
     assert(cmd.run)
     assert(cmd.success?, "RubyCommand run unsuccessfuly.")
     assert_equal(:success, cmd.status)
   end
+
   def test_error_ruby
-    cmd=RubyCommand.new("test"){raise "Error"}
+    cmd = RubyCommand.new("test") { raise "Error" }
     assert(cmd.run)
     assert(!cmd.success?, "Successful?!")
     refute(cmd.backtrace.empty?)
     assert_equal("\nError", cmd.error)
     assert_equal(:error, cmd.status)
   end
+
   def test_context
-    context="complex"
-    cmd=RubyCommand.new("test"){|c| c.output=c.context}
+    context = "complex"
+    cmd = RubyCommand.new("test") { |c| c.output = c.context }
     assert(cmd.run(context))
     assert(cmd.success?, "Not successful.")
     assert_equal(context, cmd.output)
@@ -259,78 +265,78 @@ class TestRubyCommand<Minitest::Test
   end
 end
 
-class TestCommandSequenceStatus<Minitest::Test
+class TestCommandSequenceStatus < Minitest::Test
   def test_new
-    st=Patir::CommandSequenceStatus.new("sequence")
+    st = Patir::CommandSequenceStatus.new("sequence")
     assert(!st.running?)
     assert(!st.success?)
     assert_equal(:not_executed, st.status)
     assert_nil(st.step_state(3))
   end
-  
+
   def test_step_equal
-    st=Patir::CommandSequenceStatus.new("sequence")
-    step1=MockCommandObject.new
-    step2=MockCommandWarning.new
-    step3=MockCommandError.new
+    st = Patir::CommandSequenceStatus.new("sequence")
+    step1 = MockCommandObject.new
+    step2 = MockCommandWarning.new
+    step3 = MockCommandError.new
     step1.run
-    step1.number=1
+    step1.number = 1
     step2.run
-    step2.number=2
+    step2.number = 2
     step3.run
-    step3.number=3
-    st.step=step1
+    step3.number = 3
+    st.step = step1
     assert_equal(:success, st.status)
     assert_equal(step1.status, st.step_state(1)[:status])
-    st.step=step2
+    st.step = step2
     assert_equal(:warning, st.status)
-    st.step=step3
+    st.step = step3
     assert_equal(:error, st.status)
-    step2.number=1
-    st.step=step2
+    step2.number = 1
+    st.step = step2
     assert_equal(step2.status, st.step_state(1)[:status])
     assert_equal(:error, st.status)
-    st.step=step1
+    st.step = step1
     assert_equal(:error, st.status)
     refute_nil(st.summary)
   end
-  
+
   def test_completed?
-    st=Patir::CommandSequenceStatus.new("sequence")
-    step1=MockCommandObject.new
-    step1.number=1
-    step2=MockCommandWarning.new
-    step2.number=2
-    step3=MockCommandError.new
-    step3.number=3
-    step4=MockCommandObject.new
-    step4.number=4
-    st.step=step1
-    st.step=step2
-    st.step=step3
-    st.step=step4
+    st = Patir::CommandSequenceStatus.new("sequence")
+    step1 = MockCommandObject.new
+    step1.number = 1
+    step2 = MockCommandWarning.new
+    step2.number = 2
+    step3 = MockCommandError.new
+    step3.number = 3
+    step4 = MockCommandObject.new
+    step4.number = 4
+    st.step = step1
+    st.step = step2
+    st.step = step3
+    st.step = step4
     assert(!st.completed?, "should not be complete.")
     step1.run
-    st.step=step1
+    st.step = step1
     assert(!st.completed?, "should not be complete.")
     step2.run
-    st.step=step2
+    st.step = step2
     assert(!st.completed?, "should not be complete.")
-    step2.strategy=:fail_on_warning
-    st.step=step2
+    step2.strategy = :fail_on_warning
+    st.step = step2
     assert(st.completed?, "should be complete.")
-    step2.strategy=nil
-    st.step=step2
+    step2.strategy = nil
+    st.step = step2
     assert(!st.completed?, "should not be complete.")
     step3.run
-    step3.strategy=:fail_on_error
-    st.step=step3
+    step3.strategy = :fail_on_error
+    st.step = step3
     assert(st.completed?, "should be complete.")
-    step3.strategy=nil
-    st.step=step3
+    step3.strategy = nil
+    st.step = step3
     assert(!st.completed?, "should not be complete.")
     step4.run
-    st.step=step4
+    st.step = step4
     assert(st.completed?, "should be complete.")
     refute_nil(st.summary)
   end

--- a/test/test_patir_command.rb
+++ b/test/test_patir_command.rb
@@ -310,6 +310,16 @@ class TestRubyCommand < Minitest::Test
   end
 
   ##
+  # Verify that an exception is thrown if no block is passed on initialization
+  def test_initialization_failure
+    assert_raises(
+      RuntimeError, "A block must be provided to RubyCommand upon initialization"
+    ) do
+      Patir::RubyCommand.new("A third command")
+    end
+  end
+
+  ##
   # Verify that a valid block invocation is handled as expected
   def test_normal_execution
     cmd = Patir::RubyCommand.new("Successful command") { sleep 1 }


### PR DESCRIPTION
This increases test coverage and fixes RuboCop offenses.

One functional change is dropping the unused `@run` member variable from _RubyCommand_.