### PR TITLE
Fix bug of faulty exit status in case of timeout

### DIFF
--- a/lib/patir/command.rb
+++ b/lib/patir/command.rb
@@ -211,8 +211,8 @@ module Patir
           @error << "\n#{err}" unless err.empty?
         else
           status, @output, @error = systemu(@command, :cwd => @working_directory)
-          exitstatus = status.exitstatus
         end
+        exitstatus = status.exitstatus
         begin
           exited ||= status.exited?
         rescue NotImplementedError


### PR DESCRIPTION
If a timeout is set the exitstatus variable is never being updated properly This led to the behaviour that `Patir::ShellCommand` instances which got invoked with a timeout returned a non-zero exit code but were still evaluated to a status of `:success`.